### PR TITLE
Prevent notifications when not charging

### DIFF
--- a/test_smart.py
+++ b/test_smart.py
@@ -48,6 +48,17 @@ class TestEnergyCheck(unittest.TestCase):
             mock_stop.assert_called_once()
             mock_notify.assert_called_once()
 
+    @patch.object(ChargingController, "_zappi_request")
+    def test_is_charging_notify_false_suppresses_notification(self, mock_req):
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {"zappi": [{"zmo": "1", "sta": "1", "che": "1"}]}
+        mock_req.return_value = resp
+
+        with patch.object(self.notifier, "send_discord_notification") as mock_notify:
+            self.controller.is_charging(notify=False)
+            mock_notify.assert_not_called()
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- avoid sending a Discord message when checking charging status in `is_charging`
- skip notification and exit early in `main` if not charging
- test that notifications are suppressed when `notify=False`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684358cf35888328baa186f7f8e1da9d