### PR TITLE
Optimize status checks

### DIFF
--- a/test_smart.py
+++ b/test_smart.py
@@ -89,6 +89,8 @@ class TestEnergyCheck(unittest.TestCase):
             main()
 
         mock_charging.check_energy_delivered.assert_not_called()
+        mock_client_cls.assert_not_called()
+        mock_token_cls.assert_not_called()
         mock_client_cls.return_value.check_battery_level.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- reuse HTTP digest auth object
- add `get_status` to fetch Zappi status once
- allow `is_charging`, `check_energy_delivered`, and `stop_charging` to share status
- lazily create Smartcar token manager and client
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843e44de36083289e64c20f53bfb7cb