### PR TITLE
Send notifications only when charging

### DIFF
--- a/smart.py
+++ b/smart.py
@@ -36,7 +36,7 @@ def main() -> None:
 
     try:
         status = charging_controller.get_status()
-        if not charging_controller.is_charging(status=status, notify=False):
+        if not charging_controller.is_charging(status=status):
             logging.info("Not currently charging")
             exit(1)
         else:


### PR DESCRIPTION
## Summary
- Notify via Discord only when Zappi isn't in stop mode
- Update main flow for new is_charging signature
- Add tests to ensure notifications occur only during charging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c3c7d90a0832888cf06fc327bc828