### PR TITLE
Ensure zappi mode comparisons are type-safe

### DIFF
--- a/charging_controller.py
+++ b/charging_controller.py
@@ -11,9 +11,9 @@ from notification_service import NotificationService
 
 MYENERGI_BASE_URL = "https://s18.myenergi.net"
 BATTERY_THRESHOLD = 0.8
-ZAPPI_CHARGING_STATUS = "3"
-ZAPPI_STOP_MODE = "4"
-ZAPPI_STOP_MODE_STRING = "4-0-0-0000"
+ZAPPI_CHARGING_STATUS = 3
+ZAPPI_STOP_MODE = 4
+ZAPPI_STOP_MODE_STRING = f"{ZAPPI_STOP_MODE}-0-0-0000"
 
 
 
@@ -52,8 +52,8 @@ class ChargingController:
             status = self.get_status()
         try:
             zappi_data = status["zappi"][0]
-            zappi_mode = zappi_data.get("zmo", "")
-            charging_status = zappi_data.get("sta", "")
+            zappi_mode = int(zappi_data.get("zmo", 0))
+            charging_status = int(zappi_data.get("sta", 0))
             charge_amount = zappi_data.get("che", "")
             logging.debug("Zappi status: %s", json.dumps(status, indent=2))
             zappi_status = f"mode={zappi_mode}, status={charging_status}"
@@ -64,7 +64,7 @@ class ChargingController:
                     f"{zappi_status}, {charge_amount}"
                 )
             return is_charging
-        except (KeyError, IndexError) as e:
+        except (KeyError, IndexError, ValueError) as e:
             logging.error(f"Invalid zappi response format: {e}")
             raise ChargingError(f"Invalid zappi response format: {e}")
 

--- a/test_smart.py
+++ b/test_smart.py
@@ -50,8 +50,8 @@ class TestEnergyCheck(unittest.TestCase):
             mock_notify.assert_called_once()
 
     def test_is_charging_notifies_only_when_charging(self):
-        charging_status = {"zappi": [{"zmo": "1", "sta": "3", "che": "1"}]}
-        idle_status = {"zappi": [{"zmo": "4", "sta": "1", "che": "1"}]}
+        charging_status = {"zappi": [{"zmo": 1, "sta": 3, "che": "1"}]}
+        idle_status = {"zappi": [{"zmo": 4, "sta": 1, "che": "1"}]}
 
         with patch.object(self.notifier, "send_discord_notification") as mock_notify:
             assert self.controller.is_charging(status=charging_status)


### PR DESCRIPTION
## Summary
- Treat Zappi status mode values as integers and compare against integer constants
- Update Zappi stop mode string to derive from integer constant
- Adjust tests to use integer mode values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c4d0d06788328824d298ead1fab83